### PR TITLE
Add update wizard to convert thumbnail field to FAL reference

### DIFF
--- a/Classes/Command/HarvestCommand.php
+++ b/Classes/Command/HarvestCommand.php
@@ -95,7 +95,7 @@ class HarvestCommand extends BaseCommand
      * @param InputInterface $input The input parameters
      * @param OutputInterface $output The Symfony interface for outputs on console
      *
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -104,10 +104,8 @@ class HarvestCommand extends BaseCommand
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());
 
-        $startingPoint = 0;
-        if (MathUtility::canBeInterpretedAsInteger($input->getOption('pid'))) {
-            $startingPoint = MathUtility::forceIntegerInRange((int) $input->getOption('pid'), 0);
-        }
+        $startingPoint = $this->initializeDocumentRepository($input->getOption('pid'));
+
         if ($startingPoint == 0) {
             $io->error('ERROR: No valid PID (' . $startingPoint . ') given.');
             exit(1);
@@ -254,6 +252,8 @@ class HarvestCommand extends BaseCommand
         }
 
         $io->success('All done!');
+
+        return 0;
     }
 
     /**

--- a/Classes/Command/HarvestCommand.php
+++ b/Classes/Command/HarvestCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -100,9 +99,6 @@ class HarvestCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // Make sure the _cli_ user is loaded
-        Bootstrap::getInstance()->initializeBackendAuthentication();
-
         $dryRun = $input->getOption('dry-run') != false ? true : false;
 
         $io = new SymfonyStyle($input, $output);
@@ -237,7 +233,7 @@ class HarvestCommand extends BaseCommand
             ];
             $docLocation = $baseLocation . http_build_query($params);
             // ...index the document...
-            $doc = Document::getInstance($docLocation, $startingPoint, true);
+            $doc = Document::getInstance($docLocation, ['storagePid' => $startingPoint], true);
             if ($doc->ready) {
                 if ($dryRun) {
                     $io->writeln('DRY RUN: Would index ' . $doc->uid . ' ("' . $doc->location . '") on PID ' . $startingPoint . ' and Solr core ' . $solrCoreUid . '.');

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -88,7 +88,7 @@ class IndexCommand extends BaseCommand
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());
 
-        $startingPoint = $this->getStartingPoint($input->getOption('pid'));
+        $startingPoint = $this->initializeDocumentRepository($input->getOption('pid'));
 
         if ($startingPoint == 0) {
             $io->error('ERROR: No valid PID (' . $startingPoint . ') given.');
@@ -164,6 +164,7 @@ class IndexCommand extends BaseCommand
         }
 
         $io->success('All done!');
+
         return 0;
     }
 }

--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use Kitodo\Dlf\Command\BaseCommand;
@@ -80,13 +79,10 @@ class IndexCommand extends BaseCommand
      * @param InputInterface $input The input parameters
      * @param OutputInterface $output The Symfony interface for outputs on console
      *
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // Make sure the _cli_ user is loaded
-        Bootstrap::getInstance()->initializeBackendAuthentication();
-
         $dryRun = $input->getOption('dry-run') != false ? true : false;
 
         $io = new SymfonyStyle($input, $output);
@@ -148,7 +144,7 @@ class IndexCommand extends BaseCommand
         }
 
         // Get the document...
-        $doc = Document::getInstance($input->getOption('doc'), $startingPoint, true);
+        $doc = Document::getInstance($input->getOption('doc'), ['storagePid' => $startingPoint], true);
         if ($doc->ready) {
             if ($dryRun) {
                 $io->section('DRY RUN: Would index ' . $doc->uid . ' ("' . $doc->location . '") on PID ' . $startingPoint . ' and Solr core ' . $solrCoreUid . '.');
@@ -168,5 +164,6 @@ class IndexCommand extends BaseCommand
         }
 
         $io->success('All done!');
+        return 0;
     }
 }

--- a/Classes/Command/ReindexCommand.php
+++ b/Classes/Command/ReindexCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -92,9 +91,6 @@ class ReindexCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // Make sure the _cli_ user is loaded
-        Bootstrap::getInstance()->initializeBackendAuthentication();
-
         $dryRun = $input->getOption('dry-run') != false ? true : false;
 
         $io = new SymfonyStyle($input, $output);
@@ -162,7 +158,7 @@ class ReindexCommand extends BaseCommand
         }
 
         foreach ($documents as $id => $document) {
-            $doc = Document::getInstance($document, $startingPoint, true);
+            $doc = Document::getInstance($document, ['storagePid' => $startingPoint], true);
             if ($doc->ready) {
                 if ($dryRun) {
                     $io->writeln('DRY RUN: Would index ' . $id . '/' . count($documents) . ' ' . $doc->uid . ' ("' . $doc->location . '") on PID ' . $startingPoint . ' and Solr core ' . $solrCoreUid . '.');

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -123,7 +123,7 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     /**
      * Finds all documents for the given collections
      *
-     * @param array $collections separated by comma
+     * @param array $collections
      * @param int $limit
      *
      * @return array|\TYPO3\CMS\Extbase\Persistence\QueryResultInterface
@@ -147,7 +147,10 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
                 $query->logicalAnd($constraints)
             );
         }
-        $query->setLimit((int) $limit);
+
+        if ($limit > 0) {
+            $query->setLimit((int) $limit);
+        }
 
         return $query->execute();
     }

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -85,7 +85,7 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
      */
     public function findOneByIdAndSettings($uid, $settings = [])
     {
-        $settings['documentSets'] = $uid;
+        $settings = ['documentSets' => $uid];
 
         return $this->findDocumentsBySettings($settings)->getFirst();
     }

--- a/Classes/Updates/FileLocationUpdater.php
+++ b/Classes/Updates/FileLocationUpdater.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * (c) Kitodo. Key to digital objects e.V. <contact@kitodo.org>
+ *
+ * This file is part of the Kitodo and TYPO3 projects.
+ *
+ * @license GNU General Public License version 3 or later.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Kitodo\Dlf\Updates;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+use TYPO3\CMS\Install\Updates\ChattyInterface;
+
+use Doctrine\DBAL\DBALException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+
+/**
+ * Migrate reference of thumbnail image in collections record.
+ */
+class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * @var ResourceStorage
+     */
+    protected $storage;
+
+    /**
+     * @var Logger
+     */
+    protected $logger;
+
+    /**
+     * Array with table and fields to migrate
+     *
+     * @var string
+     */
+    protected $fieldsToMigrate = [
+        'tx_dlf_collections' => 'thumbnail'
+    ];
+
+    /**
+     * @return string Unique identifier of this updater
+     */
+    public function getIdentifier(): string
+    {
+        return 'dlfFileLocationUpdater';
+    }
+
+    /**
+     * Return the speaking name of this wizard
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return 'Migrate file references used in EXT:dlf';
+    }
+
+    /**
+     * Get description
+     *
+     * @return string Longer description of this updater
+     */
+    public function getDescription(): string
+    {
+        return 'Convert file reference of thumbnail in in collection records.';
+    }
+
+    /**
+     * Is an update necessary?
+     *
+     * Is used to determine whether a wizard needs to be run.
+     * Check if data for migration exists.
+     *
+     * @return bool
+     */
+    public function updateNecessary(): bool
+    {
+        $numRecords = $this->getRecordsFromTable(true);
+        if ($numRecords > 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @return string[] All new fields and tables must exist
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class
+        ];
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Execute the update
+     *
+     * Called when a wizard reports that an update is necessary
+     *
+     * @return bool
+     */
+    public function executeUpdate(): bool
+    {
+        $result = true;
+        try {
+            $numRecords = $this->getRecordsFromTable(true);
+            if ($numRecords > 0) {
+                $this->performUpdate();
+            }
+        } catch (\Exception $e) {
+            // If something goes wrong, migrateField() logs an error
+            $result = false;
+        }
+        return $result;
+    }
+
+    /**
+     * Get records from table where the field to migrate is not empty (NOT NULL and != '')
+     * and also not numeric (which means that it is migrated)
+     *
+     * Work based on BackendLayoutIconUpdateWizard::class
+     *
+     * @return array|int
+     * @throws \RuntimeException
+     */
+    protected function getRecordsFromTable($countOnly = false)
+    {
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $allResults = [];
+        $numResults = 0;
+        foreach(array_keys($this->fieldsToMigrate) as $table) {
+            $queryBuilder = $connectionPool->getQueryBuilderForTable($table);
+            $queryBuilder->getRestrictions()->removeAll();
+            try {
+                $result = $queryBuilder
+                    ->select('uid', 'pid', $this->fieldsToMigrate[$table])
+                    ->from($table)
+                    ->where(
+                        $queryBuilder->expr()->isNotNull($this->fieldsToMigrate[$table]),
+                        $queryBuilder->expr()->neq(
+                            $this->fieldsToMigrate[$table],
+                            $queryBuilder->createNamedParameter('', \PDO::PARAM_STR)
+                        ),
+                        $queryBuilder->expr()->comparison(
+                            'CAST(CAST(' . $queryBuilder->quoteIdentifier($this->fieldsToMigrate[$table]) . ' AS DECIMAL) AS CHAR)',
+                            ExpressionBuilder::NEQ,
+                            'CAST(' . $queryBuilder->quoteIdentifier($this->fieldsToMigrate[$table]) . ' AS CHAR)'
+                        )
+                    )
+                    ->orderBy('uid')
+                    ->execute()
+                    ->fetchAll();
+                if ($countOnly === true) {
+                    $numResults += count($result);
+                } else {
+                    $allResults[$table] = $result;
+                }
+            } catch (DBALException $e) {
+                throw new \RuntimeException(
+                    'Database query failed. Error was: ' . $e->getPrevious()->getMessage(),
+                    1511950673
+                );
+            }
+        }
+
+        if ($countOnly === true) {
+            return $numResults;
+        } else {
+            return $allResults;
+        }
+    }
+
+
+    /**
+     * Performs the database update.
+     *
+     * @return bool TRUE on success, FALSE on error
+     */
+    protected function performUpdate(): bool
+    {
+        $result = true;
+        $title = "Perform Update";
+
+        try {
+            $storages = GeneralUtility::makeInstance(StorageRepository::class)->findAll();
+            $this->storage = $storages[0];
+
+            $records = $this->getRecordsFromTable();
+            foreach ($records as $table => $recordsInTable) {
+                foreach ($recordsInTable as $record) {
+                    $this->migrateField($table, $record);
+                }
+            }
+        } catch (\Exception $e) {
+            $result = false;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Migrates a single field.
+     *
+     * @param string $table
+     * @param array $row
+     * @throws \Exception
+     */
+    protected function migrateField($table, $row)
+    {
+        $fieldItem = trim($row[$this->fieldsToMigrate[$table]]);
+
+        if (empty($fieldItem) || is_numeric($fieldItem)) {
+            return;
+        }
+        $fileadminDirectory = rtrim($GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir'], '/') . '/';
+        $i = 0;
+
+        $storageUid = (int)$this->storage->getUid();
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+
+        $fileUid = null;
+        $sourcePath = Environment::getPublicPath() . '/'  . $fieldItem;
+
+        // maybe the file was already moved, so check if the original file still exists
+        if (file_exists($sourcePath)) {
+            $title = 'Migrate field ' . $sourcePath;
+
+            // see if the file already exists in the storage
+            $fileSha1 = sha1_file($sourcePath);
+
+            $queryBuilder = $connectionPool->getQueryBuilderForTable('sys_file');
+            $existingFileRecord = $queryBuilder->select('uid')->from('sys_file')->where(
+                $queryBuilder->expr()->eq(
+                    'missing',
+                    $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'sha1',
+                    $queryBuilder->createNamedParameter($fileSha1, \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->eq(
+                    'storage',
+                    $queryBuilder->createNamedParameter($storageUid, \PDO::PARAM_INT)
+                )
+            )->execute()->fetch();
+
+            // the file exists
+            if (is_array($existingFileRecord)) {
+                $fileUid = $existingFileRecord['uid'];
+            }
+        }
+
+        if ($fileUid > 0) {
+            $fields = [
+                'fieldname' => $this->fieldsToMigrate[$table],
+                'table_local' => 'sys_file',
+                'pid' => ($table === 'pages' ? $row['uid'] : $row['pid']),
+                'uid_foreign' => $row['uid'],
+                'uid_local' => $fileUid,
+                'tablenames' => $table,
+                'crdate' => time(),
+                'tstamp' => time(),
+                'sorting_foreign' => $i,
+            ];
+
+            $queryBuilder = $connectionPool->getQueryBuilderForTable('sys_file_reference');
+
+            $result = $queryBuilder
+                ->insert('sys_file_reference')
+                ->values($fields)
+                ->execute();
+
+            ++$i;
+        }
+
+        // Update referencing table's original field to now contain the count of references,
+        // but only if all new references could be set
+        if ($i === 1) {
+            $queryBuilder = $connectionPool->getQueryBuilderForTable($table);
+            $queryBuilder->update($table)->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT)
+                )
+            )->set($this->fieldsToMigrate[$table], $i)->execute();
+        }
+    }
+}

--- a/Classes/Updates/FileLocationUpdater.php
+++ b/Classes/Updates/FileLocationUpdater.php
@@ -64,7 +64,7 @@ class FileLocationUpdater implements UpgradeWizardInterface, ChattyInterface, Lo
      */
     public function getIdentifier(): string
     {
-        return 'dlfFileLocationUpdater';
+        return self::class;
     }
 
     /**

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -15,6 +15,10 @@
  * is the name of the command (to be called as the first argument after "typo3").
  * Required parameter is the "class" of the command which needs to be a subclass
  * of \Symfony\Component\Console\Command\Command.
+ *
+ * This file is deprecated in TYPO3 v10 and will be removed in TYPO3 v11.
+ * See Deprecation: #89139 - Console Commands configuration format Commands.php
+ * https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Deprecation-89139-ConsoleCommandsConfigurationFormatCommandsPhp.html
  */
 return [
     'kitodo:harvest' => [

--- a/Configuration/Flexforms/OaiPmh.xml
+++ b/Configuration/Flexforms/OaiPmh.xml
@@ -125,7 +125,7 @@
                                     </numIndex>
                                 </foreign_types>
                                 <foreign_match_fields>
-                                    <fieldname>stylesheet</fieldname> <!-- CAUTION!! Replace "fal" with the variable name of this field! -->
+                                    <fieldname>stylesheet</fieldname>
                                 </foreign_match_fields>
                                 <appearance type="array">
                                     <newRecordLinkAddTitle>1</newRecordLinkAddTitle>

--- a/Configuration/Flexforms/PageGrid.xml
+++ b/Configuration/Flexforms/PageGrid.xml
@@ -61,7 +61,7 @@
                                     </numIndex>
                                 </foreign_types>
                                 <foreign_match_fields>
-                                    <fieldname>image</fieldname> <!-- CAUTION!! Replace "fal" with the variable name of this field! -->
+                                    <fieldname>image</fieldname>
                                 </foreign_match_fields>
                                 <appearance type="array">
                                     <newRecordLinkAddTitle>1</newRecordLinkAddTitle>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,23 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Kitodo\Dlf\:
+    resource: '../Classes/*'
+
+  Kitodo\Dlf\Command\HarvestCommand:
+    tags:
+      - name: 'console.command'
+        command: 'kitodo:harvest'
+
+  Kitodo\Dlf\Command\IndexCommand:
+    tags:
+      - name: 'console.command'
+        command: 'kitodo:index'
+
+  Kitodo\Dlf\Command\ReindexCommand:
+    tags:
+      - name: 'console.command'
+        command: 'kitodo:reindex'

--- a/Configuration/TCA/tx_dlf_collections.php
+++ b/Configuration/TCA/tx_dlf_collections.php
@@ -173,11 +173,20 @@ return [
             'exclude' => 1,
             'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:dlf/Resources/Private/Language/Labels.xml:tx_dlf_collections.thumbnail',
-            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('image', [
-                'appearance' => [
-                    'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+                'image',
+                [
+                    'appearance' => [
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference'
+                    ],
+                    'foreign_match_fields' => [
+                        'fieldname' => 'thumbnail',
+                        'tablenames' => 'tx_dlf_collections',
+                        'table_local' => 'sys_file',
+                    ],
                 ],
-            ], $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'])
+                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
+            )
         ],
         'priority' => [
             'exclude' => 1,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -106,6 +106,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][] = [
 // Add migration wizards
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\Kitodo\Dlf\Updates\MigrateSettings::class]
     = \Kitodo\Dlf\Updates\MigrateSettings::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\Kitodo\Dlf\Updates\FileLocationUpdater::class]
+    = \Kitodo\Dlf\Updates\FileLocationUpdater::class;
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
     'Kitodo.Dlf',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -201,7 +201,7 @@ CREATE TABLE tx_dlf_collections (
     index_search text NOT NULL,
     oai_name varchar(255) DEFAULT '' NOT NULL,
     description text NOT NULL,
-    thumbnail int(11) NOT NULL,
+    thumbnail text NOT NULL,
     priority smallint(6) DEFAULT '3' NOT NULL,
     documents int(11) DEFAULT '0' NOT NULL,
     owner int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
This makes it easier to migrate. It's currently only the thumbnail field of the collection record which must be converted.

I reverted the change of the field type of `thumbnail` back to `text` as this seems common in 9.5. Haven't checked 10.4 yet.